### PR TITLE
Adding testbench for testing Python environment and miniscoPy functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+*.lib
+*.exp
+*.obj
+*.pyd
 *.pyc
-/dist/
-/*.egg-info
-/.ipynb_checkpoints/*
+./dist/*
+./build/*
+oasis.cpp
+./*.egg-info
+./.ipynb_checkpoints/*
 *.hdf5
 *.avi

--- a/testbench/test_import_packages.py
+++ b/testbench/test_import_packages.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import unittest
+
+class CTestImportPackages(unittest.TestCase):
+    def test_import(self):
+        self.assertTrue(self.is_import_OK())
+    #
+    def is_import_OK(self):
+        try: import scipy
+        except ImportError:
+            print("\nThe NumPy package is missing. Please install it.")
+            return False
+        #
+        try: import numpy
+        except ImportError:
+            print("\nThe SciPy package is missing. Please install it.")
+            return False
+        #
+        try: import av
+        except ImportError:
+            print("\nERROR: The PyAV package is missing. Please install it.")
+            return False
+        #
+        try: import cv2
+        except ImportError:
+            print("\nERROR: The OpenCV package is missing. Please install it.")
+            return False
+        #
+        try: import yaml
+        except ImportError:
+            print("\nERROR: The PyYAML package is missing. Please install it.")
+            return False
+        #
+        try: import pandas
+        except ImportError:
+            print("\nERROR: The Pandas package is missing. Please install it.")
+            return False
+        #
+        try: import h5py
+        except ImportError:
+            print("\nERROR: The H5py package is missing. Please install it.")
+            return False
+        #
+        try: import tqdm
+        except ImportError:
+            print("\nERROR: The Tqdm package is missing. Please install it.")
+            return False
+        #
+        try: import skimage
+        except ImportError:
+            print("\nERROR: The PyYAML package is missing. Please install it.")
+            return False
+        #
+        try: import sklearn
+        except ImportError:
+            print("\nERROR: The scikit-learn package is missing. Please install it.")
+            return False
+        #
+        return True
+    #
+#
+
+if __name__ == '__main__':
+    unittest.main()
+#

--- a/testbench/test_numpy_deadlock_mp.py
+++ b/testbench/test_numpy_deadlock_mp.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import unittest
+import multiprocessing as mp
+import numpy as np
+
+def target_func(n):
+    tmp1 = np.identity(n)
+    tmp2 = np.linalg.inv(tmp1)
+#
+
+class CTestNumpyDeadlockMultiProc(unittest.TestCase):
+    def test_deadlock_mp(self):
+        # for additional information regarding this issue see:
+        # https://github.com/numpy/numpy/issues/11041
+        # https://github.com/numpy/numpy/issues/4813
+        # https://github.com/numpy/numpy/issues/654
+        # 
+        print("\nINFO: this test should be done in less than a minute...")
+        print("INFO: Numpy version: %s" % np.version.full_version)
+        num_of_proc = mp.cpu_count()
+        target_args = [1024] * num_of_proc
+        pool = mp.Pool(num_of_proc)
+        pool.map(target_func, target_args)
+        print("INFO: Done! The test PASSED.")
+    #
+#
+
+if __name__ == '__main__':
+    unittest.main()
+#

--- a/testbench/test_numpy_deadlock_sp.py
+++ b/testbench/test_numpy_deadlock_sp.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+import unittest
+
+class CTestNumpyDeadlockSingleProc(unittest.TestCase):
+    def test_deadlock_sp(self):
+        # for additional information regarding this issue see:
+        # https://github.com/numpy/numpy/issues/11041
+        # https://github.com/numpy/numpy/issues/4813
+        # https://github.com/numpy/numpy/issues/654
+        # 
+        import numpy as np
+        print("\nINFO: this test should be done in less than a minute...")
+        n = 1024
+        tmp1 = np.identity(n)
+        tmp2 = np.linalg.inv(tmp1)
+        print("INFO: Done! The test PASSED.")
+    #
+#
+
+if __name__ == '__main__':
+    unittest.main()
+#


### PR DESCRIPTION
The issue here: https://github.com/PeyracheLab/miniscoPy/issues/3 is caused by broken numpy package. In order to be able to distinguish between bugs caused by underlying Python packages and problems within miniscoPy I suggest to create a testbench folder and keep there all the scripts used for testing. Also it is necessary for regression testing and ensuring reproducibility of results generated by miniscoPy.